### PR TITLE
Fix 'Say NO to Plagiarism' quest

### DIFF
--- a/sql/v1.03_db_changes/say_no_to_plagiarism.sql
+++ b/sql/v1.03_db_changes/say_no_to_plagiarism.sql
@@ -1,0 +1,8 @@
+/* 
+Quest: Say 'NO' to Plagiarism (2017)
+Issue: Unable to complete quest due to Spirit of Rock's Music Score not dropping from Spirit of Rock.
+*/
+
+-- Adding Spirit of Rock's Music Score (4000538) into drop table of Spirit of Rock (4300013)
+INSERT INTO maplesolaxia.drop_data (`dropperid`, `itemid`, `minimum_quantity`, `maximum_quantity`, `questid`, `chance`)
+VALUES (4300013, 4000538, 1, 1, 2288, 600000);


### PR DESCRIPTION
This change fixes the "Say 'NO' to Plagiarism" quest (quest id 2288). 

It does this by making Spirit of Rock (mob id 4300013) drop Spirit of Rock's Music Score (item id 4000538) 100% of the time when the Say 'NO' to Plagiarism quest is active/started.

This is done by adding the item to Spirit of Rock's drop table in the database. The included sql file should be executed to do this.