### PR TITLE
[FIX] Orbis PQ Leader cannot clear stage 1

### DIFF
--- a/src/net/server/Server.java
+++ b/src/net/server/Server.java
@@ -751,8 +751,13 @@ public class Server implements Runnable {
                 System.out.println("Worlds + Channels are offline.");
                 acceptor.unbind();
                 acceptor = null;
-                if (!restart) {
-                    System.exit(0);
+                if (!restart) {  // shutdown hook deadlocks if System.exit() method is used within its body chores, thanks MIKE for pointing that out
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            System.exit(0);
+                        }
+                    }).start();
                 } else {
                     System.out.println("\r\nRestarting the server....\r\n");
                     try {


### PR DESCRIPTION
Also removed requirement for leader to speak with Chamberlain Eak to clear a room, and removed upper level limit for Orbis PQ.