### PR TITLE
feature/Nerfing equip stats gains on level up

### DIFF
--- a/src/net/server/Server.java
+++ b/src/net/server/Server.java
@@ -751,8 +751,13 @@ public class Server implements Runnable {
                 System.out.println("Worlds + Channels are offline.");
                 acceptor.unbind();
                 acceptor = null;
-                if (!restart) {
-                    System.exit(0);
+                if (!restart) {  // shutdown hook deadlocks if System.exit() method is used within its body chores, thanks MIKE for pointing that out
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            System.exit(0);
+                        }
+                    }).start();
                 } else {
                     System.out.println("\r\nRestarting the server....\r\n");
                     try {


### PR DESCRIPTION
WORK IN PROGRESS, feedback required.

Nerfs stat gains on weapons upon leveling up. Current settings per level are:  
5-10% boost (based on default stats) for HP, MP, attack, defense and jump,
25-40% boost for attributes, speed, accuracy and avoidability.

Reverse/Timeless items not yet changed, and from the looks of the code, is exempt from any and all additional status gains other items enjoy. In other words, Reverse/Timeless items are in their vanilla state and likely worse than regular items at max level. In fact, I don't even know if they grant additional skill levels upon max level, because I don't see code related to it in Equip.java.